### PR TITLE
Fix extension file dependency

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -214,7 +214,7 @@ define php::extension(
     file_line { "Set_prio ${lowercase_title}":
       path              => "${config_root_ini}/${lowercase_title}.ini",
       line              => "; priority=${priority}",
-      require           => Package[$real_package],
+      require           => :Php::Config[$title],
       match             => '^; priority\=',
       match_for_absence => true,
       multiple          => false,


### PR DESCRIPTION
For PECL installed extensions, the `Set_prio` was running before `config` which results on a 404 error for the extension INI file. This PR changes dependency of the step to make sure the file is created (package is already required in the config step)

Related issue: https://github.com/sweepbright/infrastructure/issues/525